### PR TITLE
joyent/mdb_v8#23 support V8 4.4.x and 4.5.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 ## Unreleased changes
 
+* #23 support V8 4.4.x and 4.5.x
+
 * #25 fix ia32 build
 
 * #20 want ::jsfunctions -l

--- a/src/mdb_v8_impl.h
+++ b/src/mdb_v8_impl.h
@@ -62,6 +62,7 @@ extern intptr_t V8_SCOPEINFO_IDX_FIRST_VARS;
 extern intptr_t V8_SCOPEINFO_IDX_NCONTEXTLOCALS;
 extern intptr_t V8_SCOPEINFO_IDX_NPARAMS;
 extern intptr_t V8_SCOPEINFO_IDX_NSTACKLOCALS;
+extern intptr_t V8_SCOPEINFO_OFFSET_STACK_LOCALS;
 
 extern intptr_t V8_HeapObjectTag;
 extern intptr_t V8_HeapObjectTagMask;

--- a/src/v8dbg.h
+++ b/src/v8dbg.h
@@ -49,7 +49,10 @@
 #define	V8_TYPE_STRING(type)	(((type) & V8_IsNotStringMask) == V8_StringTag)
 
 #define	V8_STRENC_ASCII(type)	\
-	(((type) & V8_StringEncodingMask) == V8_AsciiStringTag)
+	((V8_AsciiStringTag != -1 && \
+		((type) & V8_StringEncodingMask) == V8_AsciiStringTag) || \
+	(V8_OneByteStringTag != -1 && \
+		((type) & V8_StringEncodingMask) == V8_OneByteStringTag))
 
 #define	V8_STRREP_SEQ(type)	\
 	(((type) & V8_StringRepresentationMask) == V8_SeqStringTag)
@@ -72,6 +75,6 @@
 	((V8_SMI_VALUE(x) & V8_PROP_TYPE_MASK) == V8_PROP_TYPE_FIELD)
 
 #define	V8_PROP_FIELDINDEX(value)	\
-	((V8_SMI_VALUE(value) & V8_FIELDINDEX_MASK) >> V8_FIELDINDEX_SHIFT)
+	((V8_SMI_VALUE(value) & V8_PROPINDEX_MASK) >> V8_PROPINDEX_SHIFT)
 
 #endif /* _V8DBG_H */

--- a/test/standalone/tst.postmortem_details.js
+++ b/test/standalone/tst.postmortem_details.js
@@ -65,7 +65,7 @@ gcore.on('exit', function (code) {
 
 	var mdb = spawn('mdb', args, { stdio: 'pipe' });
 
-	mdb.on('exit', function (code2) {
+	mdb.stdin.on('end', function (code2) {
 		unlinkSync(tmpfile);
 		var retained = '; core retained as ' + corefile;
 

--- a/test/standalone/tst.postmortem_findjsobjects.js
+++ b/test/standalone/tst.postmortem_findjsobjects.js
@@ -43,7 +43,7 @@ gcore.on('exit', function (code) {
 
 	var mdb = spawn('mdb', args, { stdio: 'pipe' });
 
-	mdb.on('exit', function (code2) {
+	mdb.stdin.on('end', function (code2) {
 		var retained = '; core retained as ' + corefile;
 
 		if (code2 != 0) {


### PR DESCRIPTION
This PR updates mdb_v8 to support V8 4.4.x and 4.5.x.

* It uses `v8dbg_propindex_mask` instead of `v8dbg_fieldindex_mask`, and `v8dbg_propindex_shift` instead of `v8dbg_fieldindex_shift`. The [`v8dbg_propindex*` values were already present](https://github.com/nodejs/node-v0.x-archive/commit/f3836af2) when the [`v8dbg_fieldindex` values were added](https://github.com/nodejs/node-v0.x-archive/commit/9a960c270c4ca48e05ccc915135845a1e2120e94), and they represented the same values. So instead of going back to naming these values `fieldindex_*` and having to usptream these changes to V8, I chose to change what values we use in mdb_v8.c instead.

* It adds a `V8_CONSTANT_ADDED_SINCE` macro and a function named `v8_version_at_least` to mark and determine when a constant or an offset was added by a given V8 version. It's used to support [the new `OneByteStringTag` constant](https://github.com/nodejs/node/blame/master/deps/v8/tools/gen-postmortem-metadata.py#L64), and `Maps`' `constructor` offset that [has been renamed to `constructor_or_backpointer`](https://github.com/nodejs/node/commit/d58e780504bdba6c5897c48428fd984c5b5f96fe).

* `struct v8_offset` now also has a `flags` member so that we can determine when `Maps`' `constructor` offset was renamed to `constructor_or_backpointer` using `V8_CONSTANT_ADDED_SINCE`.

* Finally `tst.postmortem_details.js` and `tst.postmortem_findjsobjects.js` were failing because of a race condition between the child process' `exit` event and the stdin's `end` event.

These changes have been tested with core files generated from 32 and 64 bits versions of nodejs/node master that use V8 4.4.x and 4.5.x, as well as with node v0.12.7 64 bits. All tests pass.

I will perform more testing, specifically with node v0.10.x 32bits and 64bits, and with node v0.12.7 32 bits. In the meantime, any feedback would be very much appreciated.
