### PR TITLE
joyent/mdb_v8#25: fix ia32 build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 ## Unreleased changes
 
+* #25 fix ia32 build
+
 * #20 want ::jsfunctions -l
 
 ## v0.11.1 (2015-08-20)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,6 +89,9 @@ include Makefile.arch.defs
 $(MDBV8_TARGETS_amd64):	CFLAGS	+= -m64
 $(MDBV8_TARGETS_amd64):	SOFLAGS	+= -m64
 
+$(MDBV8_TARGETS_ia32): CFLAGS += -m32
+$(MDBV8_TARGETS_ia32): SOFLAGS += -m32
+
 #
 # DEFINITIONS USED AS RECIPES
 #


### PR DESCRIPTION
On 64 bits systems, force generation of 32bits binary objects by specifying `CFLAGS` and `SOFLAGS`.

Fixes #25.