### PR TITLE
joyent/mdb_v8#32: fix ::findjsobjects for V8 4.5.x

### DIFF
--- a/test/standalone/tst.postmortem_findjsobjects.js
+++ b/test/standalone/tst.postmortem_findjsobjects.js
@@ -43,7 +43,7 @@ gcore.on('exit', function (code) {
 
 	var mdb = spawn('mdb', args, { stdio: 'pipe' });
 
-	mdb.stdin.on('end', function (code2) {
+	mdb.on('exit', function (code2) {
 		var retained = '; core retained as ' + corefile;
 
 		if (code2 != 0) {


### PR DESCRIPTION
This fixes ::findjsobjects for core dumps generated by Node.js 4.0.x
(and possibly later).

This change fixes how mdb_v8 retrieves the constructor of a JavaScript
object given its Map.

It also fixes the problem of accessing objects' properties that was
caused by a typo in "v8db_propindex_mask" that should have been
"v8db_prop_index_mask" (note the underscore in "prop_index") in my
previous changes.

It adds a "fallback" member for v8_offsets so that we can have a
fallback for typed arrays' length's offset.

Finally, this change allows ::findjsobjects to find Buffer instances and
inspect them. However, due to how Buffer instances are implemented in
node v4.x and later, they are currently seen by mdb_v8 as having a
constructor named "Uint8Array" instead of "Buffer", so ::findjsobjects
-c Buffer won't find any actual Buffer instances, instead one has to use
::findjsobjects -c Uint8Array.