### PR TITLE
joyent/mdb_v8#40: fix JSArrayBufferView's buffer offset missing

### DIFF
--- a/src/mdb_v8.c
+++ b/src/mdb_v8.c
@@ -505,8 +505,15 @@ static v8_offset_t v8_offsets[] = {
 	    "JSArrayBuffer", "backing_store",
 	    B_FALSE, V8_CONSTANT_FALLBACK(4, 6), 11 },
 #endif
+#ifdef _LP64
 	{ &V8_OFF_JSARRAYBUFFERVIEW_BUFFER,
-	    "JSArrayBufferView", "buffer" },
+	    "JSArrayBufferView", "buffer",
+	    B_FALSE, V8_CONSTANT_FALLBACK(3, 20), 23 },
+#else
+	{ &V8_OFF_JSARRAYBUFFERVIEW_BUFFER,
+	    "JSArrayBufferView", "buffer",
+	    B_FALSE, V8_CONSTANT_FALLBACK(3, 20), 11 },
+#endif
 #ifdef _LP64
 	{ &V8_OFF_JSARRAYBUFFERVIEW_CONTENT_OFFSET,
 	    "JSArrayBufferView", "byte_offset",

--- a/test/standalone/tst.postmortem_load.js
+++ b/test/standalone/tst.postmortem_load.js
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var common = require('./common');
+var assert = require('assert');
+var os = require('os');
+var path = require('path');
+var util = require('util');
+
+/*
+ * Now we're going to fork ourselves to gcore
+ */
+var spawn = require('child_process').spawn;
+var prefix = '/var/tmp/node';
+var corefile = prefix + '.' + process.pid;
+var gcore = spawn('gcore', [ '-o', prefix, process.pid + '' ]);
+var output = '';
+var unlinkSync = require('fs').unlinkSync;
+var args = [ corefile ];
+
+if (process.env.MDB_LIBRARY_PATH && process.env.MDB_LIBRARY_PATH != '')
+	args = args.concat([ '-L', process.env.MDB_LIBRARY_PATH ]);
+
+gcore.stderr.on('data', function (data) {
+	console.log('gcore: ' + data);
+});
+
+gcore.on('exit', function (code) {
+	if (code != 0) {
+		console.error('gcore exited with code ' + code);
+		process.exit(code);
+	}
+
+	var mdb = spawn('mdb', args, { stdio: 'pipe' });
+
+	mdb.on('exit', function (code2) {
+		var retained = '; core retained as ' + corefile;
+
+		if (code2 != 0) {
+			console.error('mdb exited with code ' +
+			    util.inspect(code2) + retained);
+			process.exit(code2);
+		}
+
+		unlinkSync(corefile);
+		process.exit(0);
+	});
+
+	mdb.stderr.on('data', function (data) {
+		assert(false,
+		    'loading mdb_v8 should not generate any output on stderr');
+	});
+
+	var mod = util.format('::load %s\n', common.dmodpath());
+	mdb.stdin.write(mod);
+	mdb.stdin.end();
+});


### PR DESCRIPTION
https://codereview.chromium.org/17153011introduced JSArrayBufferView's buffer field (which was previously JSTypedArray's buffer field). The earliest tag in V8's repository with this change is 3.21.18:
```
$ git tag --contains 91eb5f8d2550a117fec3a41c3e2241ee13460dd0 | head -1
3.21.18
$
```
but it landed in nodejs/node as [an upgrade to V8 3.20.2](https://github.com/nodejs/node/commit/704fd8f3745527fc080f96e54e5ec1857c505399) (you may not be able to see the actual change in GitHub's web interface, in this case just use `git show 704fd8f3745527fc080f96e54e5ec1857c505399` in a local clone of nodejs/node and search for `class JSArrayBufferView`).

As a result, the fallback value has been set for V8 3.20. I've also made sure that no extra accessor needs to be added to `gen-postmortem-metadata.py` in V8.