### PR TITLE
joyent/mdb_v8#72: tests cannot run on non-release versions of node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 ## Unreleased changes
 
-None.
+* #72: tests cannot run on non-release versions of node
 
 ## v1.1.3 (2016-06-03)
 

--- a/test/lib/runtime-versions.js
+++ b/test/lib/runtime-versions.js
@@ -12,15 +12,17 @@ function getNodeVersions() {
 		return cachedVersions.node;
 	}
 
-	NODE_VERSIONS = process.versions.node.split('.');
+	NODE_VERSIONS =
+		process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)(\-\w+)?$/);
+	assert.ok(NODE_VERSIONS);
 
-	NODE_MAJOR = Number(NODE_VERSIONS[0]);
+	NODE_MAJOR = Number(NODE_VERSIONS[1]);
 	assert.equal(isNaN(NODE_MAJOR), false);
 
-	NODE_MINOR = Number(NODE_VERSIONS[1]);
+	NODE_MINOR = Number(NODE_VERSIONS[2]);
 	assert.equal(isNaN(NODE_MINOR), false);
 
-	NODE_PATCH = Number(NODE_VERSIONS[2]);
+	NODE_PATCH = Number(NODE_VERSIONS[3]);
 	assert.equal(isNaN(NODE_PATCH), false);
 
 	cachedVersions.node = {


### PR DESCRIPTION
Fixes #72. Tested with node current development version, v7.0.0-pre:

```
[jgilli@dev ~/mdb_v8]$ git diff
diff --git a/test/lib/runtime-versions.js b/test/lib/runtime-versions.js
index e40ca86..dd51fff 100644
--- a/test/lib/runtime-versions.js
+++ b/test/lib/runtime-versions.js
@@ -12,15 +12,17 @@ function getNodeVersions() {
                return cachedVersions.node;
        }
 
-       NODE_VERSIONS = process.versions.node.split('.');
+       NODE_VERSIONS =
+               process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)(\-\w+)?$/);
+       assert.ok(NODE_VERSIONS);
 
-       NODE_MAJOR = Number(NODE_VERSIONS[0]);
+       NODE_MAJOR = Number(NODE_VERSIONS[1]);
        assert.equal(isNaN(NODE_MAJOR), false);
 
-       NODE_MINOR = Number(NODE_VERSIONS[1]);
+       NODE_MINOR = Number(NODE_VERSIONS[2]);
        assert.equal(isNaN(NODE_MINOR), false);
 
-       NODE_PATCH = Number(NODE_VERSIONS[2]);
+       NODE_PATCH = Number(NODE_VERSIONS[3]);
        assert.equal(isNaN(NODE_PATCH), false);
 
        cachedVersions.node = {
[jgilli@dev ~/mdb_v8]$ ../node/node --version
v7.0.0-pre
[jgilli@dev ~/mdb_v8]$ ../node/node test/standalone/tst.jsclosure.js 
> ::load /home/jgilli/mdb_v8/build/amd64/mdb_v8.so
mdb_v8 version: 1.1.4 (dev)
V8 version: 5.0.71.52
Autoconfigured V8 support from target
C++ symbol demangling enabled

> ::jsfunctions -n myClosure ! awk 'NR == 2{ print $1 }'
2847b30991b1

> 2847b30991b1::jsclosure
    "str": 2656373538f9: "hello world"
    "count": 900000000: 9

> 2847b30991b1::v8function
2847b30991b1: JSFunction: myClosure
defined at /home/jgilli/mdb_v8/test/standalone/tst.jsclosure.js position 814
context: 2847b309b981
shared scope_info: 2656373607c9
code: 2a4a2134a5e1
instructions: [2a4a2134a640, 2a4a2134a704)

> 2847b309b981::v8context
closure function: 2847b3018c31 (JSFunction)
previous context: 2847b3018df9 (FixedArray)
extension: e87486041e9 (Oddball: "hole")
native context: e87486ae061 (FixedArray)
    slot 0: 2656373538f9 (<unknown>)
    slot 1: 900000000 (SMI: value = 9)

> 2847b3018c31::v8function ! awk '/shared scope_info:/{ print $3 }'
265637360691

> 265637360691::v8scopeinfo
1 parameter
    parameter 0: 1fcbc75ec7d1 ("str")
1 stack local variable
    stack local variable 0: 2656373538b1 ("myClosure")
2 context local variables
    context local variable 0: 1fcbc75ec7d1 ("str")
    context local variable 1: 1fcbc75ec649 ("count")

test passed
[jgilli@dev ~/mdb_v8]$
```

All tests pass with `./tools/runtests_node run`.